### PR TITLE
Implement Typography alias tokens

### DIFF
--- a/bin/build.py
+++ b/bin/build.py
@@ -14,8 +14,13 @@ def parse_token_name(value):
 def parse_token_value(value, css_variable):
     if type(value) is dict:
         return None
+    elif value.isnumeric():
+        # Mostly applied to `fontWeights`.
+        return value
     else:
         if('{' in value):
+            value = value.lower()
+
             if(True == css_variable):
                 return 'var(--{0})'.format(re.sub('[{}]+', '', value))
             else:
@@ -35,7 +40,7 @@ def parse_line(token_name, value, tab, css_variable):
         return '{0}${1}: {2};\n'.format(tab, token_name, value)
 
 def write_line(value, line, tokens_primitives, tokens_component_specific):
-    # Having `var()` or `$` means that are component spcific token
+    # Having `var()` or `$` means that are component spcific tokens
     if "var" not in value and "$" not in value:
         tokens_primitives.write(line)
     else:


### PR DESCRIPTION
## Description
This is a follow up of #11 

### What is included
1. Parse the font-weight values and cast as `numbers` 
2. After a couple of discussions with the Houssam, we've decided to use the variant of texts (`headings` and `paragraphs`) as tokens. This could be more reliable and easy to maintain in the future.

### About the item 2
#### Primitive font families
```css
--font-family-greenpeace-sans: "GreenpeaceSans";
--font-family-source-serif-pro: "SourceSerifPro";
--font-family-source-sans-3: "SourceSans3";
--font-family-source-sans-3-bold: "SourceSans3-Bold";
```
They will be used to fetch and the declare a new font family through the master theme
```css
$bucket: "https://www.greenpeace.org/static/planet4-assets/";

$fonts: (
  #{$font-family-source-sans-3},
  #{$font-family-source-sans-3-bold},
  #{$font-family-source-sans-3-semi-bold},
);

@each $font in $fonts {
  @font-face {
    font-family: #{$font};
    src: url(#{$bucket} + #{$font} + ".woff2") format('woff2');
  }
}
```

And the alias tokens are parsed as
```css

--font-family-heading: var(--font-family-greenpeace-sans);
--font-family-paragraph-primary-bold: var(--font-family-source-serif-pro);
--font-family-paragraph-primary-medium: var(--font-family-source-serif-pro);
--font-family-paragraph-primary-regular: var(--font-family-source-serif-pro);
--font-family-paragraph-secondary-medium: var(--font-family-source-sans-3);
--font-family-paragraph-secondary-regular: var(--font-family-source-sans-3);
--font-family-paragraph-secondary-bold: var(--font-family-source-sans-3-bold);
```
By doing this, the cost of the maintenance is considerably reduced. Since in case of case of changing a new font we're only edit the primitive token.

**Heads up!**
The next step should be to re think the primitive typography tokens to something more generic, like converting `font-family-greenpeace-sans` to `font-family-primary`